### PR TITLE
更新文檔

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A stock system simulator game which use acgn characters as company.
 
 1. sign in your github account
 2. choose issue label
-3. click new issue 
+3. click new issue
 4. write title and body
 5. send and wait for contributors reponse
 
@@ -18,8 +18,9 @@ A stock system simulator game which use acgn characters as company.
 
 1. Install [Meteor](https://www.meteor.com/install)
 2. git clone this project from github
-3. type `meteor npm install` in project folder
-4. type `meteor run --settings config.json` in project folder
+3. type `meteor --version` in project folder (let meteor install right version for this project)
+4. type `meteor npm install` in project folder
+5. type `meteor run --settings config.json` in project folder
 
 ## Documentation
 

--- a/docs/prerender.md
+++ b/docs/prerender.md
@@ -4,6 +4,8 @@
 
 Since the setup process is a little bit complicated, we wrote down this how-to document to help those in need.
 
+**This is not necessary**, you can just skip this if you won't develop anything about SEO.
+
 ## Setting Up a Prerender Server
 
 To enable this functionality, you will need a **prerender server** to handle the request.
@@ -14,7 +16,7 @@ If you don't want to run your own prerender server, check out [PrerenderIO](http
 
 ### Run Your Own Prerender Server
 
-If you choose to run your own prerender server, follow these steps:
+If you choose to run your own prerender server, you can use our [prerender-server](https://github.com/ACGN-stock/acgn-stock-prerender-server) project, or follow these steps to develop your server:
 
 1. install [Chrome](https://www.google.com/chrome/)
 

--- a/docs/prerender.md
+++ b/docs/prerender.md
@@ -12,7 +12,7 @@ To enable this functionality, you will need a **prerender server** to handle the
 
 If you don't want to run your own prerender server, check out [PrerenderIO](https://prerender.io/) for their hosted service.
 
-### Run Your Own Prerender Server 
+### Run Your Own Prerender Server
 
 If you choose to run your own prerender server, follow these steps:
 
@@ -25,10 +25,10 @@ If you choose to run your own prerender server, follow these steps:
    ```sh
    npm install prerender --save
    ```
-   
+
    **IMPORTANT NOTE: Don't try to install prerender server in your `acgn-stock` project!**
-   
-   We tried to integrate prerender into this project (see #589, #591). Since then we encountered some serious issues which prevent `acgn-stock` from working, so we decided to remove it (see #597). 
+
+   We tried to integrate prerender into this project (see [#589](https://github.com/ACGN-stock/acgn-stock/pull/589), [#591](https://github.com/ACGN-stock/acgn-stock/pull/591)). Since then we encountered some serious issues which prevent `acgn-stock` from working, so we decided to remove it (see [#597](https://github.com/ACGN-stock/acgn-stock/pull/597)).
 
 3. write `index.js`
    ```js
@@ -49,7 +49,7 @@ If you choose to run your own prerender server, follow these steps:
    ```sh
    node index.js
    ```
-   
+
 After the server is started, you can connect to, for example, `http://localhost:3900/https://github.com/`, to see if it works.
 
 


### PR DESCRIPTION
1. 註明 `prerender` 並不是必要的、修復文檔內的連結、並建議使用股市已經開發的prerender-server
2. 在啟動股市的步驟增加 `meteor --version` 指令，避免meteor沒有使用正確的npm版本