### PR TITLE
改進 Google Analytics 追蹤 - 紀錄切換的頁面、分開 prod & dev 的 Tracking ID 、不紀錄 Headless Chrome 帶來的流量

### DIFF
--- a/client/layout/layout.html
+++ b/client/layout/layout.html
@@ -5,7 +5,6 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'UA-143586675-1');
   </script>
 
   <meta charset="utf-8" />

--- a/client/layout/layout.js
+++ b/client/layout/layout.js
@@ -4,6 +4,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { DocHead } from 'meteor/kadira:dochead';
 
 import { rMainTheme } from '/client/utils/styles';
+import { updatePathToGA } from '/client/utils/googleAnalytics/updatePathToGA';
 import { getCurrentPage, getCurrentPageFullTitle } from '/routes';
 import { rAccountDialogMode } from './accountDialog';
 import { rShowAlertDialog, alertDialog } from './alertDialog';
@@ -12,6 +13,7 @@ Template.layout.onRendered(function() {
   this.autorun(() => {
     FlowRouter.watchPathChange();
     DocHead.setTitle(getCurrentPageFullTitle());
+    updatePathToGA();
   });
 });
 

--- a/client/utils/googleAnalytics/updatePathToGA.js
+++ b/client/utils/googleAnalytics/updatePathToGA.js
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
 let lastPath = '';
@@ -9,7 +10,7 @@ export function updatePathToGA() {
   }
   lastPath = path;
 
-  const gaTrackingId = 'UA-143586675-1';
+  const gaTrackingId = Meteor.settings.public.google.analytics;
   gtag('config', gaTrackingId, { 'page_path': path });
 }
 

--- a/client/utils/googleAnalytics/updatePathToGA.js
+++ b/client/utils/googleAnalytics/updatePathToGA.js
@@ -1,0 +1,39 @@
+import { FlowRouter } from 'meteor/kadira:flow-router';
+
+let lastPath = '';
+
+export function updatePathToGA() {
+  const { path } = FlowRouter.current();
+  if (path === lastPath) {
+    return;
+  }
+  lastPath = path;
+
+  const gaTrackingId = 'UA-143586675-1';
+  gtag('config', gaTrackingId, { 'page_path': path });
+}
+
+function gtag() {
+  const dataLayer = window.dataLayer;
+  if (isPathData(dataLayer[dataLayer.length - 1])) {
+    // 避免陣列太大
+    dataLayer.pop();
+  }
+  // GA一定要直接丟 arguments 進去，用其他方式放進去沒有反應
+  dataLayer.push(arguments); // eslint-disable-line prefer-rest-params
+}
+
+function isPathData(data) {
+  if (typeof data !== 'object') {
+    return false;
+  }
+  if (data[0] !== 'config') {
+    return false;
+  }
+  if (typeof data[2] !== 'object' || typeof data[2].page_path !== 'string') {
+    return false;
+  }
+
+  return true;
+}
+

--- a/client/utils/googleAnalytics/updatePathToGA.js
+++ b/client/utils/googleAnalytics/updatePathToGA.js
@@ -1,9 +1,15 @@
 import { Meteor } from 'meteor/meteor';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 
+import { isHeadlessChrome } from '/client/utils/isHeadlessChrome';
+
 let lastPath = '';
 
 export function updatePathToGA() {
+  if (isHeadlessChrome()) {
+    return;
+  }
+
   const { path } = FlowRouter.current();
   if (path === lastPath) {
     return;

--- a/config.js
+++ b/config.js
@@ -12,6 +12,9 @@ export const config = {
     use: false, // 是否使用prerender功能 (需要另外架設prerender server)
     url: 'http://127.0.0.1:3900/' // prerender server的位置
   },
+  google: {
+    analytics: 'UA-143586675-2' // GA Tracking ID (結尾 -1: prod, -2: dev)
+  },
   intervalTimer: 60000, // 每隔多少毫秒進行一次工作檢查
   releaseStocksForHighPriceInterval: { // 高價釋股的排程時間範圍 (ms)
     min: 10800000,

--- a/config.json
+++ b/config.json
@@ -12,6 +12,9 @@
       "use": false,
       "url": "http://127.0.0.1:3900/"
     },
+    "google": {
+      "analytics": "UA-143586675-2"
+    },
     "intervalTimer": 60000,
     "releaseStocksForHighPriceInterval": {
       "min": 10800000,


### PR DESCRIPTION
SPA網頁切換頁面時，必須自行將紀錄發給GA才會記錄

---

分開不同環境使用的 GA Tracking ID ，避免開發時的流量被記錄至GA

**production 請將 config 中的 google.analytics 的值改為 UA-143586675-1**
如下
```json
    "google": {
      "analytics": "UA-143586675-1"
    },
```

---

使用 Headless Chrome 爬取網站資料時，不將資料收集至GA