### PR TITLE
公允價值系統

### DIFF
--- a/db/dbCompanies.js
+++ b/db/dbCompanies.js
@@ -80,9 +80,18 @@ export function isHighPriceCompany(companyData) {
 }
 
 /**
+ * @typedef {Object} UpperAndLower
+ * @property {Number} upper
+ * @property {Number} lower
+ */
+/**
  * 取得買賣單的上下限
- * @param {Object} companyData 內容必須包含 listPrice, capital, totalValue, createdAt
- * @returns {Object} upper, lower
+ * @param {Object} companyData 計算上下限所需的資訊
+ * @param {Number} companyData.listPrice listPrice
+ * @param {Number} companyData.capital capital
+ * @param {Number} companyData.totalValue totalValue
+ * @param {Date} companyData.createdAt createdAt
+ * @returns {UpperAndLower} { upper, lower }
  */
 export function getPriceLimits(companyData) {
   const upper = getPriceUpperLimit(companyData);
@@ -101,6 +110,8 @@ function getPriceUpperLimit(companyData) {
     upperPrice = companyData.listPrice * priceLimits.normal.upper;
   }
 
+  upperPrice = Math.max(upperPrice, getFairPrice(companyData));
+
   return Math.ceil(upperPrice);
 }
 
@@ -118,6 +129,13 @@ function getPriceLowerLimit(companyData) {
   }
 
   return Math.max(Math.floor(lowerPrice), 1);
+}
+
+// 公允價格
+function getFairPrice({ totalValue, listPrice, capital }) {
+  const totalRelease = totalValue / listPrice;
+
+  return Math.ceil(capital / totalRelease);
 }
 
 function isValueLowerThanCapital(companyData) {

--- a/integration-test/server/functions/company/releaseStocksForHighPrice.test.js
+++ b/integration-test/server/functions/company/releaseStocksForHighPrice.test.js
@@ -44,6 +44,7 @@ describe('function releaseStocksForHighPrice', function() {
     });
 
     expect(orderData).to.exist();
+    companyData.listPrice.must.be.equal(companyData.lastPrice); // 應更新股價
     orderData.unitPrice.must.be.equal(getPriceLimits(beforeCompanyData).upper); // 漲停價
     orderData.amount.must.be.between(1, Math.floor(Math.sqrt(totalRelease)));
 

--- a/integration-test/server/functions/company/releaseStocksForHighPrice.test.js
+++ b/integration-test/server/functions/company/releaseStocksForHighPrice.test.js
@@ -1,9 +1,8 @@
-import { Meteor } from 'meteor/meteor';
 import { resetDatabase } from 'meteor/xolvio:cleaner';
 import expect from 'must';
 import mustSinon from 'must-sinon';
 
-import { dbCompanies } from '/db/dbCompanies';
+import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
 import { dbOrders } from '/db/dbOrders';
 import { dbLog } from '/db/dbLog';
 import { dbVariables } from '/db/dbVariables';
@@ -31,10 +30,12 @@ describe('function releaseStocksForHighPrice', function() {
   });
 
   it('should create a !system sell order', function() {
+    const beforeCompanyData = dbCompanies.findOne(companyId);
+
     releaseStocksForHighPrice();
 
     const companyData = dbCompanies.findOne(companyId);
-    const { totalRelease, listPrice } = companyData;
+    const { totalRelease } = companyData;
 
     const orderData = dbOrders.findOne({
       orderType: '賣出',
@@ -43,7 +44,7 @@ describe('function releaseStocksForHighPrice', function() {
     });
 
     expect(orderData).to.exist();
-    orderData.unitPrice.must.be.equal(Math.ceil(listPrice * Meteor.settings.public.priceLimits.normal.upper)); // 漲停價
+    orderData.unitPrice.must.be.equal(getPriceLimits(beforeCompanyData).upper); // 漲停價
     orderData.amount.must.be.between(1, Math.floor(Math.sqrt(totalRelease)));
 
     const logData = dbLog.findOne({ logType: '公司釋股', companyId });

--- a/integration-test/server/functions/company/releaseStocksForNoDeal.test.js
+++ b/integration-test/server/functions/company/releaseStocksForNoDeal.test.js
@@ -60,7 +60,11 @@ describe('function releaseStocksForNoDeal', function() {
 
   it('should release stocks', function() {
     dbOrders.insert(buyOrderFactory.build());
+
     releaseStocksForNoDeal();
+
+    const companyData = dbCompanies.findOne(companyId);
+    companyData.listPrice.must.be.equal(companyData.lastPrice);
     expect(dbLog.findOne({ logType: '公司釋股', companyId })).to.exist();
   });
 

--- a/server/functions/company/recordListPrice.js
+++ b/server/functions/company/recordListPrice.js
@@ -1,9 +1,9 @@
-import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 
 import { resourceManager } from '/server/imports/threading/resourceManager';
 import { dbCompanies } from '/db/dbCompanies';
 import { dbVariables } from '/db/dbVariables';
+import { executeBulksSync } from '/server/imports/utils/executeBulksSync';
 
 export function updateRecordListPricePeriod() {
   const { min: intervalMin, max: intervalMax } = Meteor.settings.public.recordListPriceInterval;
@@ -16,27 +16,20 @@ export function updateRecordListPricePeriod() {
 // 更新參考價（與參考市值）
 export function recordListPrice() {
   resourceManager.requestPromise('recordListPrice', ['allCompanyOrders'], (release) => {
-    const companyUpdateModifierMap = dbCompanies
+    const companyBulk = dbCompanies.rawCollection().initializeUnorderedBulkOp();
+    dbCompanies
       .find({ isSeal: false }, { fields: { lastPrice: 1, totalRelease: 1 } })
       .fetch()
-      .reduce((obj, { _id: companyId, lastPrice, totalRelease }) => {
-        obj[companyId] = {
-          $set: {
+      .forEach(({ _id: companyId, lastPrice, totalRelease }) => {
+        companyBulk
+          .find({ _id: companyId })
+          .updateOne({ $set: {
             listPrice: lastPrice,
             totalValue: lastPrice * totalRelease
-          }
-        };
-
-        return obj;
-      }, {});
-
-    if (! _.isEmpty(companyUpdateModifierMap)) {
-      const companyBulk = dbCompanies.rawCollection().initializeUnorderedBulkOp();
-      Object.entries(companyUpdateModifierMap).forEach(([companyId, modifier]) => {
-        companyBulk.find({ _id: companyId }).updateOne(modifier);
+          } });
       });
-      Meteor.wrapAsync(companyBulk.execute, companyBulk)();
-    }
+
+    executeBulksSync(companyBulk);
 
     release();
   });

--- a/server/functions/company/recordListPrice.js
+++ b/server/functions/company/recordListPrice.js
@@ -20,9 +20,9 @@ export function recordListPrice() {
     dbCompanies
       .find({ isSeal: false }, { fields: { lastPrice: 1, totalRelease: 1 } })
       .fetch()
-      .forEach(({ _id: companyId, lastPrice, totalRelease }) => {
+      .forEach(({ _id, lastPrice, totalRelease }) => {
         companyBulk
-          .find({ _id: companyId })
+          .find({ _id })
           .updateOne({ $set: {
             listPrice: lastPrice,
             totalValue: lastPrice * totalRelease

--- a/server/functions/company/recordListPrice.js
+++ b/server/functions/company/recordListPrice.js
@@ -34,3 +34,12 @@ export function recordListPrice() {
     release();
   });
 }
+
+// TODO 在重構 createOrder 後，應嘗試由 createOrder 實作，減少 DB 更新次數
+export function recordOneCompanyListPrice(companyId) {
+  const { lastPrice, totalRelease } = dbCompanies.findOne(companyId, { fields: { lastPrice: 1, totalRelease: 1 } });
+  dbCompanies.update(companyId, { $set: {
+    listPrice: lastPrice,
+    totalValue: lastPrice * totalRelease
+  } });
+}

--- a/server/functions/company/releaseStocksForHighPrice.js
+++ b/server/functions/company/releaseStocksForHighPrice.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 
+import { recordOneCompanyListPrice } from '/server/functions/company/recordListPrice';
 import { createOrder } from '/server/imports/createOrder';
 import { resourceManager } from '/server/imports/threading/resourceManager';
 import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
@@ -62,6 +63,7 @@ export function releaseStocksForHighPrice() {
           unitPrice: releasePrice,
           amount: releaseStocks
         });
+        recordOneCompanyListPrice(companyId);
         release();
       });
     });

--- a/server/functions/company/releaseStocksForNoDeal.js
+++ b/server/functions/company/releaseStocksForNoDeal.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 
+import { recordOneCompanyListPrice } from '/server/functions/company/recordListPrice';
 import { createOrder } from '/server/imports/createOrder';
 import { resourceManager } from '/server/imports/threading/resourceManager';
 import { dbCompanies, getPriceLimits } from '/db/dbCompanies';
@@ -60,6 +61,7 @@ export function releaseStocksForNoDeal() {
           unitPrice: releasePrice,
           amount: releaseStocks
         });
+        recordOneCompanyListPrice(companyId);
         release();
       });
     });


### PR DESCRIPTION
依照公告 (https://acgn-stock.com/announcement/view/HieAB8S32yb9JEQxa) 實作公允價值系統

---

為避免與會計的 `fair value` 搞混，命名上使用 `fair price` 

在釋股更新價格的部分，為提早更新以趕上賽季第3週實裝，用效能較差的方式實作 (在完成釋股後更新)
在完成 `createOrder` 的自動測試與重構後，應將價格與市值更新交由 `createOrder` 內實作，以減少更新 DB 的次數