### PR TITLE
將廣告移至最底部並只隨機顯示一個

### DIFF
--- a/client/advertising/advertising.html
+++ b/client/advertising/advertising.html
@@ -90,6 +90,11 @@
   <form>
     <h3 class="card-subtitle text-muted">購買廣告</h3>
     <hr />
+    <div>
+      <span class="text-danger">請注意廣告空間有顯示上限，不同裝置能顯示的字數不同</span><br />
+      <span>建議內容在20字以內，較能在多數裝置顯示</span>
+    </div>
+    <hr />
     <div class="small">
       ＊必須
     </div>

--- a/client/layout/footer.html
+++ b/client/layout/footer.html
@@ -6,19 +6,11 @@
         {{> displayAnnouncementUnreadNotification}}
         {{> unreadImportantFscLogsNotification}}
         {{> displayLegacyAnnouncement}}
-        {{#each advertisingList}}
-          {{> displayAdvertising}}
-        {{/each}}
       </div>
-      <div class="bg-faded text-primary text-right px-3 py-1 rounded">
-        <a
-          class="text-danger float-left"
-          href="https://github.com/ACGN-stock/acgn-stock/issues"
-          target="_blank"
-        >
-          Bug回報
-        </a>
-        伺服器連線數量：{{onlinePeopleNumber}}
+      <div class="bg-faded text-center px-3 py-1 rounded" style="max-height: 50px;">
+        {{#if advertising}}
+          {{> displayAdvertising advertising}}
+        {{/if}}
       </div>
     </div>
   </div>
@@ -87,22 +79,15 @@
 </template>
 
 <template name="displayAdvertising">
-  <div class="media bg-info px-2 py-1 my-2 rounded footer-message-container">
-    <div class="media-body footer-message">
-      來自
-      {{>userLink this.userId}}
-      的廣告：「
-      {{#if this.url}}
-        <a href="{{this.url}}" target="_blank">{{this.message}}</a>
-      {{else}}
-        {{this.message}}
-      {{/if}}
-      」
-    </div>
-    <div class="footer-message-close-button">
-      <a class="btn btn-danger btn-sm" href="#">
-        <i class="fa fa-times" aria-hidden="true"></i>
-      </a>
-    </div>
+  <div class="footer-message-container">
+    來自
+    {{>userLink this.userId}}
+    的廣告：「
+    {{#if this.url}}
+      <a href="{{this.url}}" target="_blank">{{this.message}}</a>
+    {{else}}
+      {{this.message}}
+    {{/if}}
+    」
   </div>
 </template>

--- a/client/layout/footer.js
+++ b/client/layout/footer.js
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore';
 import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 import { ReactiveVar } from 'meteor/reactive-var';
@@ -16,14 +15,12 @@ Template.footer.onCreated(function() {
     if (shouldStopSubscribe()) {
       return false;
     }
-    this.subscribe('onlinePeopleNumber');
     this.subscribe('displayAdvertising');
   });
 });
 
-const rClosedAdvertisingIdList = new ReactiveVar([]);
 Template.footer.helpers({
-  advertisingList() {
+  advertising() {
     const advertisingList = dbAdvertising
       .find({}, {
         sort: {
@@ -32,14 +29,9 @@ Template.footer.helpers({
         limit: Meteor.settings.public.displayAdvertisingNumber
       })
       .fetch();
-    const closedAdvertisingIdList = rClosedAdvertisingIdList.get();
+    const randomDisplayIndex = Math.floor(Math.random() * advertisingList.length);
 
-    return _.reject(advertisingList, (advertisingData) => {
-      return _.contains(closedAdvertisingIdList, advertisingData._id);
-    });
-  },
-  onlinePeopleNumber() {
-    return dbVariables.get('onlinePeopleNumber') || 0;
+    return advertisingList[randomDisplayIndex];
   },
   containerClass() {
     if (rMainTheme.get() === 'light') {
@@ -89,14 +81,6 @@ Template.displayLegacyAnnouncement.events({
   'click .btn'(event) {
     event.preventDefault();
     rIsDisplayAnnouncement.set(false);
-  }
-});
-
-Template.displayAdvertising.events({
-  'click .btn'(event, templateInstance) {
-    event.preventDefault();
-    const closedAdvertisingIdList = rClosedAdvertisingIdList.get().slice();
-    rClosedAdvertisingIdList.set(_.union(closedAdvertisingIdList, templateInstance.data._id));
   }
 });
 

--- a/client/layout/nav.html
+++ b/client/layout/nav.html
@@ -93,6 +93,11 @@
               歷史博物館
             </a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="https://github.com/ACGN-stock/acgn-stock/issues" target="_blank">
+              BUG回報
+            </a>
+          </li>
           {{> navLink page='ruleAgendaList'}}
           {{> navLink page='violationCaseList'}}
           {{> navLink page='fscLogs'}}

--- a/client/mainPage/mainPage.html
+++ b/client/mainPage/mainPage.html
@@ -95,11 +95,8 @@
       </span>
     </div>
     <div class="col-12 col-md-6">
-      <span class="font-weight-bold text-nowrap">最近低量釋股區間：</span>
-      <span class="{{taskIsReady noDealReleaseBegin noDealReleaseEnd}}">
-        <span class="text-nowrap">{{noDealReleaseBegin}}</span>
-        <span class="text-nowrap">~ {{noDealReleaseEnd}}</span>
-      </span>
+      <span class="font-weight-bold text-nowrap">伺服器連線數量：</span>
+      <span class="text-nowrap">{{onlinePeopleNumber}}</span>
     </div>
     <div class="col-12 col-md-6">
       <span class="font-weight-bold text-nowrap">最近高價釋股區間：</span>
@@ -109,10 +106,17 @@
       </span>
     </div>
     <div class="col-12 col-md-6">
+      <span class="font-weight-bold text-nowrap">最近低量釋股區間：</span>
+      <span class="{{taskIsReady noDealReleaseBegin noDealReleaseEnd}}">
+        <span class="text-nowrap">{{noDealReleaseBegin}}</span>
+        <span class="text-nowrap">~ {{noDealReleaseEnd}}</span>
+      </span>
+    </div>
+    <div class="col-12 col-md-6">
       <span class="font-weight-bold text-nowrap">高價公司價格下限：</span>
       <span>$ {{highPriceThreshold}}</span>
     </div>
-    <div class="col-12 offset-md-6 col-md-6">
+    <div class="col-12 col-md-6">
       <span class="font-weight-bold text-nowrap">低價公司價格上限：</span>
       <span>$ {{lowPriceThreshold}}</span>
     </div>

--- a/client/mainPage/mainPage.js
+++ b/client/mainPage/mainPage.js
@@ -88,9 +88,13 @@ Template.systemStatusPanel.onCreated(function() {
     }
     this.subscribe('currentRound');
     this.subscribe('currentSeason');
+    this.subscribe('onlinePeopleNumber');
   });
 });
 Template.systemStatusPanel.helpers({
+  onlinePeopleNumber() {
+    return dbVariables.get('onlinePeopleNumber') || 0;
+  },
   roundStartTime() {
     const currentRound = dbRound.findOne({}, {
       sort: {

--- a/client/mainPage/mainPage.js
+++ b/client/mainPage/mainPage.js
@@ -26,8 +26,6 @@ Template.legacyAnnouncement.onCreated(function() {
       return false;
     }
     this.subscribe('legacyAnnouncementDetail');
-    this.subscribe('currentRound');
-    this.subscribe('currentSeason');
   });
 });
 Template.legacyAnnouncement.helpers({
@@ -83,6 +81,15 @@ function aboutToEnd(end, hour) {
   }
 }
 
+Template.systemStatusPanel.onCreated(function() {
+  this.autorun(() => {
+    if (shouldStopSubscribe()) {
+      return false;
+    }
+    this.subscribe('currentRound');
+    this.subscribe('currentSeason');
+  });
+});
 Template.systemStatusPanel.helpers({
   roundStartTime() {
     const currentRound = dbRound.findOne({}, {


### PR DESCRIPTION
 - 將 `currentRound` 與 `currentSeason` 在前端的訂閱從 `legacyAnnouncement` 移至 `systemStatusPanel`
 - 將 `伺服器連線數量` 從下方列移除，改至首頁 `systemStatusPanel` 顯示，並微調底下公告各項時間等資訊的排版
 - 將 `BUG回報` 從下方列移除，改至上方 `其他資訊` 下拉選單中
 - 廣告顯示改由下方列顯示，將從可以顯示的廣告隨機挑選一個來顯示，並設有高度限制 `50px`