### PR TITLE
修正編輯新創頁面訂閱的資料內容

### DIFF
--- a/server/publications/foundation/foundationDataForEdit.js
+++ b/server/publications/foundation/foundationDataForEdit.js
@@ -11,6 +11,7 @@ Meteor.publish('foundationDataForEdit', function(foundationId) {
 
   return dbFoundations.find(foundationId, {
     fields: {
+      companyName: 1,
       tags: 1,
       pictureSmall: 1,
       pictureBig: 1,


### PR DESCRIPTION
在編輯新創頁面如果沒有給公司名會造成前端錯誤

(由於js執行順序無法確定，並非任何時候都能重現BUG)